### PR TITLE
Updated web pack file loader, and reference font files absolute paths…

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "eslint-loader": "^1.3.0",
     "eslint-plugin-chai-expect": "^1.1.1",
     "extract-text-webpack-plugin": "^1.0.1",
-    "file-loader": "^0.9.0",
+    "file-loader": "^0.11.2",
     "font-awesome": "^4.6.1",
     "font-awesome-webpack": "0.0.4",
     "html-loader": "^0.4.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -64,15 +64,8 @@ var config = {
       },
       {
         test: FONT_REGEX,
-        loader: 'url',
-        query: {
-          // limit: 1000 // 10kb
-        }
+        loader: 'file-loader?name=[name]-[hash].[ext]&publicPath=/dist/&outputPath=fonts/'
       },
-      // {
-      //   test: FONT_REGEX,
-      //   loader: 'file'
-      // },
       {
         test: /\.html$/,
         loader: 'html'


### PR DESCRIPTION
… instead of data-url-ing

Its not the recommended way to reference assets, but the relative path solution messes up fonts not packed into styles.css (invoked by script, like font-awesome)

https://app.asana.com/0/inbox/275068761174407/356057418913986/357417889936971

**Browsers I manually tested this feature in**
* [*] Google Chrome
* [  ] Firefox
* [  ] Microsoft Edge
